### PR TITLE
Fixes for CLion configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,24 @@
 cmake_minimum_required(VERSION 3.9)
-project(scoutapm)
+project(scoutapm C)
 
-set(CMAKE_CXX_STANDARD 11)
+set(SOURCE_FILES zend_scoutapm.c zend_scoutapm.h)
 
-include_directories(/home/james/workspace/php-src/main)
-include_directories(/home/james/workspace/php-src/Zend)
-include_directories(/home/james/workspace/php-src)
-
-add_executable(scoutapm
-        zend_scoutapm.c
-        zend_scoutapm.h
+execute_process(
+        COMMAND php-config --include-dir
+        OUTPUT_VARIABLE PHP_SOURCE
 )
+string(REGEX REPLACE "\n$" "" PHP_SOURCE "${PHP_SOURCE}")
+message("Using source directory: ${PHP_SOURCE}")
+
+include_directories(${PHP_SOURCE})
+include_directories(${PHP_SOURCE}/main)
+include_directories(${PHP_SOURCE}/Zend)
+include_directories(${PHP_SOURCE}/TSRM)
+include_directories(${PROJECT_SOURCE_DIR})
+
+add_custom_target(configure
+        COMMAND phpize && ./configure
+        DEPENDS ${SOURCE_FILES}
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+
+add_library(___ EXCLUDE_FROM_ALL ${SOURCE_FILES})

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ $ ./configure --enable-scoutapm
 $ make test
 ```
 
+Note: whilst a CMakeLists.txt exists, this project does NOT use CMake.
+The CMakeLists.txt exists so this project can be worked on in CLion.
+See <https://dev.to/jasny/developing-a-php-extension-in-clion-3oo1>.
+
 ## Building with specific PHP build
 
 ```bash

--- a/config.m4
+++ b/config.m4
@@ -11,3 +11,7 @@ if test "$PHP_SCOUT_APM" != "no"; then
         zend_scoutapm.c,
         $ext_shared,, ,,yes)
 fi
+
+AC_CONFIG_COMMANDS_POST([
+  ln -s "$PHP_EXECUTABLE" build/php
+])

--- a/example.php
+++ b/example.php
@@ -1,0 +1,4 @@
+<?php
+
+file_get_contents(__FILE__);
+var_dump(scoutapm_get_calls()[0]);


### PR DESCRIPTION
PR updates CMakeLists.txt and config.m4 to allow CLion to work with the ext better (see: https://dev.to/jasny/developing-a-php-extension-in-clion-3oo1), and also not using hardcoded paths from my system :grin: 