### PR TITLE
Release 0.0.4 - version fixes, compatibility across versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ print_cvs
  - Copy the current release into a new `changelog.release` element
  - Update the current release section (date/time/version/stability/notes)
  - `pecl package-validate` to check everything looks good
+ - Increase/verify `PHP_SCOUTAPM_VERSION` version listed in `zend_scoutapm.h`
  - Commit update to `package.xml`
  - Rebuild from scratch (`full-clean.sh`, then build as above)
  - `make test` to ensure everything passes locally

--- a/package.xml
+++ b/package.xml
@@ -26,10 +26,10 @@
 
     <!-- Current Release -->
     <date>2019-09-17</date>
-    <time>10:00:00</time>
+    <time>11:15:00</time>
     <version>
-        <release>0.0.2</release>
-        <api>0.0.2</api>
+        <release>0.0.3</release>
+        <api>0.0.3</api>
     </version>
     <stability>
         <release>alpha</release>
@@ -37,9 +37,7 @@
     </stability>
     <license uri="https://opensource.org/licenses/MIT">MIT</license>
     <notes>
-        - Added extra compiler flags in development mode with `--enable-scoutapm-dev`
-        - Fixed compilation errors surfaced by `--enable-scoutapm-dev` option
-        - Added missing file `external.inc` in tests
+        - Fixed version number and naming convension so PECL uploader picks up on mismatches (last release was wrong)
     </notes>
     <!-- End Current Release -->
 
@@ -87,6 +85,24 @@
     <zendextsrcrelease />
 
     <changelog>
+        <release>
+            <date>2019-09-17</date>
+            <time>10:00:00</time>
+            <version>
+                <release>0.0.2</release>
+                <api>0.0.2</api>
+            </version>
+            <stability>
+                <release>alpha</release>
+                <api>alpha</api>
+            </stability>
+            <license uri="https://opensource.org/licenses/MIT">MIT</license>
+            <notes>
+                - Added extra compiler flags in development mode with `--enable-scoutapm-dev`
+                - Fixed compilation errors surfaced by `--enable-scoutapm-dev` option
+                - Added missing file `external.inc` in tests
+            </notes>
+        </release>
         <release>
             <date>2019-09-17</date>
             <time>09:15:00</time>

--- a/package.xml
+++ b/package.xml
@@ -25,11 +25,11 @@
     </lead>
 
     <!-- Current Release -->
-    <date>2019-09-17</date>
-    <time>11:15:00</time>
+    <date></date>
+    <time></time>
     <version>
-        <release>0.0.3</release>
-        <api>0.0.3</api>
+        <release>0.0.4</release>
+        <api>0.0.4</api>
     </version>
     <stability>
         <release>alpha</release>
@@ -37,7 +37,8 @@
     </stability>
     <license uri="https://opensource.org/licenses/MIT">MIT</license>
     <notes>
-        - Fixed version number and naming convension so PECL uploader picks up on mismatches (last release was wrong)
+        - Fixed test failing because differing behaviour of sqlite in some versions
+        - Define i/j etc to follow c89 rules (thanks @remicollet)
     </notes>
     <!-- End Current Release -->
 
@@ -85,6 +86,22 @@
     <zendextsrcrelease />
 
     <changelog>
+        <release>
+            <date>2019-09-17</date>
+            <time>11:15:00</time>
+            <version>
+                <release>0.0.3</release>
+                <api>0.0.3</api>
+            </version>
+            <stability>
+                <release>alpha</release>
+                <api>alpha</api>
+            </stability>
+            <license uri="https://opensource.org/licenses/MIT">MIT</license>
+            <notes>
+                - Fixed version number and naming convension so PECL uploader picks up on mismatches (last release was wrong)
+            </notes>
+        </release>
         <release>
             <date>2019-09-17</date>
             <time>10:00:00</time>

--- a/tests/011-pdo-exec.phpt
+++ b/tests/011-pdo-exec.phpt
@@ -7,9 +7,8 @@ Calls to PDO::exec are logged
 --FILE--
 <?php
 $dbh = new PDO('sqlite::memory:');
-echo $dbh->exec("CREATE TABLE foo (col INT PRIMARY KEY)");
-echo $dbh->exec("INSERT INTO foo (col) VALUES (1), (2) ");
-echo "\n";
+$dbh->exec("CREATE TABLE foo (col INT PRIMARY KEY)");
+$dbh->exec("INSERT INTO foo (col) VALUES (1), (2) ");
 
 $calls = scoutapm_get_calls();
 var_dump($calls[0]['function']);
@@ -18,7 +17,6 @@ var_dump($calls[1]['function']);
 var_dump($calls[1]['argv'][0]);
 ?>
 --EXPECTF--
-02
 string(9) "PDO->exec"
 string(38) "CREATE TABLE foo (col INT PRIMARY KEY)"
 string(9) "PDO->exec"

--- a/zend_scoutapm.c
+++ b/zend_scoutapm.c
@@ -44,14 +44,14 @@ static const zend_function_entry scoutapm_functions[] = {
 /* scoutapm_module_entry provides the metadata/information for PHP about this PHP module */
 static zend_module_entry scoutapm_module_entry = {
     STANDARD_MODULE_HEADER,
-    SCOUT_APM_EXT_NAME,
+    PHP_SCOUTAPM_NAME,
     scoutapm_functions,             /* function entries */
     NULL,                           /* module init */
     NULL,                           /* module shutdown */
     PHP_RINIT(scoutapm),            /* request init */
     PHP_RSHUTDOWN(scoutapm),        /* request shutdown */
     NULL,                           /* module information */
-    SCOUT_APM_EXT_VERSION,          /* module version */
+    PHP_SCOUTAPM_VERSION,           /* module version */
     PHP_MODULE_GLOBALS(scoutapm),   /* module global variables */
     NULL,
     NULL,
@@ -73,8 +73,8 @@ zend_extension_version_info extension_version_info = {
 
 /* zend_extension_entry provides the metadata/information for PHP about this zend extension */
 zend_extension zend_extension_entry = {
-    (char*) SCOUT_APM_EXT_NAME,
-    (char*) SCOUT_APM_EXT_VERSION,
+    (char*) PHP_SCOUTAPM_NAME,
+    (char*) PHP_SCOUTAPM_VERSION,
     (char*) "Scout APM",
     (char*) "https://scoutapm.com/",
     (char*) "Copyright 2019",

--- a/zend_scoutapm.h
+++ b/zend_scoutapm.h
@@ -50,7 +50,7 @@ ZEND_END_MODULE_GLOBALS(scoutapm)
 #endif
 
 /* zif_handler is not always defined, so define this roughly equivalent */
-#ifndef zif_handler
+#if PHP_VERSION_ID < 70200
 typedef void (*zif_handler)(INTERNAL_FUNCTION_PARAMETERS);
 #endif
 

--- a/zend_scoutapm.h
+++ b/zend_scoutapm.h
@@ -19,7 +19,7 @@
 #include "ext/standard/php_var.h"
 
 #define PHP_SCOUTAPM_NAME "scoutapm"
-#define PHP_SCOUTAPM_VERSION "0.0.1"
+#define PHP_SCOUTAPM_VERSION "0.0.3"
 
 /* Extreme amounts of debugging, set to 1 to enable it and `make clean && make` (tests will fail...) */
 #define SCOUT_APM_EXT_DEBUGGING 0

--- a/zend_scoutapm.h
+++ b/zend_scoutapm.h
@@ -19,7 +19,7 @@
 #include "ext/standard/php_var.h"
 
 #define PHP_SCOUTAPM_NAME "scoutapm"
-#define PHP_SCOUTAPM_VERSION "0.0.3"
+#define PHP_SCOUTAPM_VERSION "0.0.4"
 
 /* Extreme amounts of debugging, set to 1 to enable it and `make clean && make` (tests will fail...) */
 #define SCOUT_APM_EXT_DEBUGGING 0

--- a/zend_scoutapm.h
+++ b/zend_scoutapm.h
@@ -18,8 +18,8 @@
 #include <zend_exceptions.h>
 #include "ext/standard/php_var.h"
 
-#define SCOUT_APM_EXT_NAME "scoutapm"
-#define SCOUT_APM_EXT_VERSION "0.0.1"
+#define PHP_SCOUTAPM_NAME "scoutapm"
+#define PHP_SCOUTAPM_VERSION "0.0.1"
 
 /* Extreme amounts of debugging, set to 1 to enable it and `make clean && make` (tests will fail...) */
 #define SCOUT_APM_EXT_DEBUGGING 0


### PR DESCRIPTION
Naming convention should be `PHP_SCOUTAPM_VERSION` for the version - this way pecl.php.net will pick up any mismatches before uploading. Our "0.0.2" release had "0.0.1" as the version, so this release brings everything in line in 0.0.3 (rather than replacing 0.0.2, we'll consider that a buggy release)