### PR TITLE
Fixing bug #55 - crash when running doctrine/migrations tests

### DIFF
--- a/tests/bug-55.phpt
+++ b/tests/bug-55.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug https://github.com/scoutapp/scout-apm-php-ext/issues/55 - don't crash when using an observed method in extended class
+--SKIPIF--
+<?php if (!extension_loaded("scoutapm")) die("skip scoutapm extension required."); ?>
+<?php if (!extension_loaded("PDO")) die("skip PDO extension required."); ?>
+<?php if (!extension_loaded("pdo_sqlite")) die("skip pdo_sqlite extension required."); ?>
+--FILE--
+<?php
+
+class MyOwnPDO extends PDO {}
+
+$dbh = new MyOwnPDO('sqlite::memory:');
+$stmt = $dbh->query("SELECT 1 + 2");
+var_dump($stmt->fetch(PDO::FETCH_ASSOC));
+
+$calls = scoutapm_get_calls();
+var_dump($calls[0]['function']);
+var_dump($calls[0]['argv'][0]);
+?>
+--EXPECTF--
+array(1) {
+  ["1 + 2"]=>
+  string(1) "3"
+}
+string(10) "PDO->query"
+string(12) "SELECT 1 + 2"

--- a/zend_scoutapm.c
+++ b/zend_scoutapm.c
@@ -242,7 +242,7 @@ const char* determine_function_name(zend_execute_data *execute_data)
 
     if (Z_TYPE(execute_data->This) == IS_OBJECT) {
         DYNAMIC_MALLOC_SPRINTF(ret, len, "%s->%s",
-            ZSTR_VAL(Z_OBJCE(execute_data->This)->name),
+            ZSTR_VAL(execute_data->func->common.scope->name),
             ZSTR_VAL(execute_data->func->common.function_name)
         );
         return ret;


### PR DESCRIPTION
Fixes #55 - where we incorrectly determine function name when a monitored method is used in an extended class