### PR TITLE
Issue curl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ mkdep.awk
 scan_makefile_in.awk
 shtool
 /ltmain.sh
+/ltmain.sh.backup
 /mkinstalldirs
 
 # configure

--- a/config.m4
+++ b/config.m4
@@ -16,7 +16,7 @@ if test "$PHP_SCOUTAPM" != "no"; then
 
   dnl modern version provides libcurl.pc
   AC_PATH_PROG(PKG_CONFIG, wpkg-config, no)
-  dnl old version only providfes curl-config
+  dnl old version only provides curl-config
   AC_PATH_PROG(CURL_CONFIG, wcurl-config, no)
 
   AC_MSG_CHECKING(for libcurl headers)

--- a/zend_scoutapm.c
+++ b/zend_scoutapm.c
@@ -6,6 +6,7 @@
  */
 
 #include "zend_scoutapm.h"
+#include "ext/standard/info.h"
 
 double scoutapm_microtime();
 void record_arguments_for_call(const char *call_reference, int argc, zval *argv);
@@ -59,6 +60,25 @@ static const zend_function_entry scoutapm_functions[] = {
     PHP_FE_END
 };
 
+PHP_MINFO_FUNCTION(scoutapm)
+{
+	php_info_print_table_start();
+	php_info_print_table_header(2, "scoutapm support", "enabled");
+	php_info_print_table_row(2, "Version", PHP_SCOUTAPM_VERSION);
+#if HAVE_CURL
+  #if HAVE_SCOUT_CURL
+	php_info_print_table_row(2, "curl functions", "Yes");
+  #else
+	php_info_print_table_row(2, "curl functions", "Not instrumented");
+  #endif
+#else
+	php_info_print_table_row(2, "curl functions", "No");
+#endif
+	php_info_print_table_row(2, "file functions", "Yes");
+	php_info_print_table_row(2, "pdo functions", "Yes");
+	php_info_print_table_end();
+}
+
 /* scoutapm_module_entry provides the metadata/information for PHP about this PHP module */
 static zend_module_entry scoutapm_module_entry = {
     STANDARD_MODULE_HEADER,
@@ -68,7 +88,7 @@ static zend_module_entry scoutapm_module_entry = {
     NULL,                           /* module shutdown */
     PHP_RINIT(scoutapm),            /* request init */
     PHP_RSHUTDOWN(scoutapm),        /* request shutdown */
-    NULL,                           /* module information */
+    PHP_MINFO(scoutapm),            /* module information */
     PHP_SCOUTAPM_VERSION,           /* module version */
     PHP_MODULE_GLOBALS(scoutapm),   /* module global variables */
     NULL,


### PR DESCRIPTION
From discussion on 8e2cd7bddfa00a2a820d02088c4ece04adfe9e5b

This implement a check only for headers,
allowing to use non standard path

Second commit improve PHPinfo:
```
$ php -n -d zend_extension=$PWD/modules/scoutapm.so --ri scoutapm

scoutapm

scoutapm support => enabled
Version => 1.0.2
curl functions => Not instrumented
file functions => Yes
pdo functions => Yes

```