### PR TITLE
fix globals init and ZTS

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -80,7 +80,7 @@ if test "$PHP_SCOUTAPM" != "no"; then
     STD_CFLAGS="-g -O0 -Wall"
   fi
 
-  PHP_SCOUTAPM_CFLAGS="$STD_CFLAGS $MAINTAINER_CFLAGS"
+  PHP_SCOUTAPM_CFLAGS="-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 $STD_CFLAGS $MAINTAINER_CFLAGS"
 
   PHP_NEW_EXTENSION(scoutapm, zend_scoutapm.c scout_curl_wrapper.c scout_file_wrapper.c scout_pdo_wrapper.c,
         $ext_shared,,$PHP_SCOUTAPM_CFLAGS,,yes)

--- a/zend_scoutapm.c
+++ b/zend_scoutapm.c
@@ -82,6 +82,12 @@ PHP_MINFO_FUNCTION(scoutapm)
 	php_info_print_table_end();
 }
 
+static
+PHP_GINIT_FUNCTION(scoutapm)
+{
+    scoutapm_globals->handlers_set = 0;
+}
+
 /* scoutapm_module_entry provides the metadata/information for PHP about this PHP module */
 static zend_module_entry scoutapm_module_entry = {
     STANDARD_MODULE_HEADER,
@@ -94,7 +100,7 @@ static zend_module_entry scoutapm_module_entry = {
     PHP_MINFO(scoutapm),            /* module information */
     PHP_SCOUTAPM_VERSION,           /* module version */
     PHP_MODULE_GLOBALS(scoutapm),   /* module global variables */
-    NULL,
+    PHP_GINIT(scoutapm),            /* init global */
     NULL,
     NULL,
     STANDARD_MODULE_PROPERTIES_EX
@@ -105,6 +111,9 @@ static zend_module_entry scoutapm_module_entry = {
  * Instead, see `zend_scoutapm_startup` - we load the module there.
 ZEND_GET_MODULE(scoutapm);
  */
+#if defined(COMPILE_DL_SCOUTAPM) && defined(ZTS)
+ZEND_TSRMLS_CACHE_DEFINE()
+#endif
 
 /* extension_version_info is used by PHP */
 zend_extension_version_info extension_version_info = {
@@ -177,6 +186,10 @@ static PHP_RINIT_FUNCTION(scoutapm)
     zend_function *original_function;
     int handler_index;
     zend_class_entry *ce;
+
+#if defined(COMPILE_DL_SCOUTAPM) && defined(ZTS)
+	ZEND_TSRMLS_CACHE_UPDATE();
+#endif
 
     SCOUTAPM_DEBUG_MESSAGE("Initialising stacks...");
     SCOUTAPM_G(observed_stack_frames_count) = 0;

--- a/zend_scoutapm.c
+++ b/zend_scoutapm.c
@@ -85,6 +85,9 @@ PHP_MINFO_FUNCTION(scoutapm)
 static
 PHP_GINIT_FUNCTION(scoutapm)
 {
+#if defined(COMPILE_DL_SCOUTAPM) && defined(ZTS)
+	ZEND_TSRMLS_CACHE_UPDATE();
+#endif
     memset(scoutapm_globals, 0, sizeof(zend_scoutapm_globals));
 }
 

--- a/zend_scoutapm.c
+++ b/zend_scoutapm.c
@@ -85,7 +85,7 @@ PHP_MINFO_FUNCTION(scoutapm)
 static
 PHP_GINIT_FUNCTION(scoutapm)
 {
-    scoutapm_globals->handlers_set = 0;
+    memset(scoutapm_globals, 0, sizeof(zend_scoutapm_globals));
 }
 
 /* scoutapm_module_entry provides the metadata/information for PHP about this PHP module */


### PR DESCRIPTION
See #67 

2 fix:
* Use TSRM cache
* Add GINIT standard function

Test suite:
```
=====================================================================
PHP         : /usr/bin/zts-php 
PHP_SAPI    : cli
PHP_VERSION : 8.0.2
ZEND_VERSION: 4.0.2
PHP_OS      : Linux - Linux builder.remirepo.net 5.10.11-200.fc33.x86_64 #1 SMP Wed Jan 27 20:21:22 UTC 2021 x86_64
INI actual  : /builddir/build/BUILD/php-pecl-scoutapm-1.2.0/ZTS
More .INIs  :   
CWD         : /builddir/build/BUILD/php-pecl-scoutapm-1.2.0/ZTS
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
TIME START 2021-02-05 11:03:04
=====================================================================
PASS Check Scout APM extension is loaded [tests/001-check-ext-loaded.phpt] 
PASS Calls to file_get_contents are logged [tests/002-file_get_contents.phpt] 
PASS Ensures that calls to scoutapm_get_calls() clears the call list [tests/003-scoutapm_get_calls-clears-calls-list.phpt] 
PASS Calls to file_get_contents are logged [tests/004-namespaced-fgc-is-not-logged.phpt] 
PASS Requires to external files do not crash [tests/005-requiring-external-files-handled.phpt] 
PASS Executing a closure/anonymous function does not crash [tests/006-anonymous-classes-handled.phpt] 
PASS Running evaled code does not crash [tests/007-evaled-code-handled.phpt] 
PASS Class without a defined constructor does not crash [tests/008-class-with-no-constructor-call-handled.phpt] 
PASS Calls to curl_exec are logged [tests/009-curl_exec.phpt] 
PASS Calls to fwrite and fread are logged with handle from fopen() [tests/010-fwrite-fread-fopen.phpt] 
PASS Calls to fwrite and fread are logged with handle from tmpfile() [tests/010-fwrite-fread-tmpfile.phpt] 
PASS Calls to PDO::exec are logged [tests/011-pdo-exec.phpt] 
PASS Calls to PDO::query are logged [tests/011-pdo-query.phpt] 
PASS Calls to PDOStatement::execute are logged when created from PDO->prepare() [tests/011-pdostatement-execute-pdo-prepare.phpt] 
PASS Calls to file_put_contents are logged [tests/012-file_put_contents.phpt] 
SKIP When calls to functions are recorded, and scoutapm_get_calls is not called, don't leak memory [tests/013-fix-memory-leak-when-scoutapm_get_calls-not-called.phpt] reason: Recompile PHP with --enable-debug.
PASS Bug https://github.com/scoutapp/scout-apm-php-ext/issues/47 - fix segfault when accessing argument store out of bounds [tests/bug-47.phpt] 
PASS Bug https://github.com/scoutapp/scout-apm-php-ext/issues/49 - only record arguments for fopen if it returns a resource [tests/bug-49.phpt] 
=====================================================================
TIME END 2021-02-05 11:03:04

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   19
---------------------------------------------------------------------

Number of tests :   18                17
Tests skipped   :    1 (  5.6%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :   17 ( 94.4%) (100.0%)
---------------------------------------------------------------------
Time taken      :    0 seconds
=====================================================================

```