### PR TITLE
Fix memory leaks with DYNAMIC_MALLOC_SPRINTF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.4.1 - 2021-06-29
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#91](https://github.com/scoutapp/scout-apm-php-ext/pull/91) Fixed memory leaks from DYNAMIC_MALLOC_SPRINTF un-freed usages
+
 ## 1.4.0 - 2021-06-17
 
 ### Added

--- a/package.xml
+++ b/package.xml
@@ -90,6 +90,7 @@
                 <file name="bug-49.phpt" role="test" />
                 <file name="bug-55.phpt" role="test" />
                 <file name="bug-71.phpt" role="test" />
+                <file name="bug-88.phpt" role="test" />
             </dir>
         </dir>
     </contents>

--- a/package.xml
+++ b/package.xml
@@ -25,11 +25,11 @@
     </lead>
 
     <!-- Current Release -->
-    <date>2021-06-17</date>
-    <time>16:00:00</time>
+    <date>2021-06-29</date>
+    <time>12:00:00</time>
     <version>
-        <release>1.4.0</release>
-        <api>1.4.0</api>
+        <release>1.4.1</release>
+        <api>1.4.1</api>
     </version>
     <stability>
         <release>stable</release>
@@ -37,7 +37,7 @@
     </stability>
     <license uri="https://opensource.org/licenses/MIT">MIT</license>
     <notes>
-        - Only instrument if specifically enabled with scoutapm_enable_instrumentation() (#89)
+        - Fixed memory leaks from DYNAMIC_MALLOC_SPRINTF un-freed usages (#91)
     </notes>
     <!-- End Current Release -->
 
@@ -110,6 +110,22 @@
     <zendextsrcrelease />
 
     <changelog>
+        <release>
+            <date>2021-06-17</date>
+            <time>16:00:00</time>
+            <version>
+                <release>1.4.0</release>
+                <api>1.4.0</api>
+            </version>
+            <stability>
+                <release>stable</release>
+                <api>stable</api>
+            </stability>
+            <license uri="https://opensource.org/licenses/MIT">MIT</license>
+            <notes>
+                - Only instrument if specifically enabled with scoutapm_enable_instrumentation() (#89)
+            </notes>
+        </release>
         <release>
             <date>2021-06-17</date>
             <time>09:00:00</time>

--- a/scout_curl_wrapper.c
+++ b/scout_curl_wrapper.c
@@ -22,7 +22,10 @@ ZEND_NAMED_FUNCTION(scoutapm_curl_setopt_handler)
     const char *passthru_function_name;
 
 #if PHP_MAJOR_VERSION >= 8
+    const char *class_instance_id;
     ASSIGN_CURL_HANDLE_CLASS_ENTRY
+#else
+    const char *resource_id;
 #endif
 
     SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING(passthru_function_name)
@@ -39,9 +42,13 @@ ZEND_NAMED_FUNCTION(scoutapm_curl_setopt_handler)
 
     if (options == CURLOPT_URL) {
 #if PHP_MAJOR_VERSION >= 8
-        record_arguments_for_call(unique_class_instance_id(zid), 1, zvalue);
+        class_instance_id = unique_class_instance_id(zid);
+        record_arguments_for_call(class_instance_id, 1, zvalue);
+        free((void*) class_instance_id);
 #else
-        record_arguments_for_call(unique_resource_id(SCOUT_WRAPPER_TYPE_CURL, zid), 1, zvalue);
+        resource_id = unique_resource_id(SCOUT_WRAPPER_TYPE_CURL, zid);
+        record_arguments_for_call(resource_id, 1, zvalue);
+        free((void*) resource_id);
 #endif
     }
 
@@ -57,7 +64,10 @@ ZEND_NAMED_FUNCTION(scoutapm_curl_exec_handler)
     zend_long recorded_arguments_index;
 
 #if PHP_MAJOR_VERSION >= 8
+    const char *class_instance_id;
     ASSIGN_CURL_HANDLE_CLASS_ENTRY
+#else
+    const char *resource_id;
 #endif
 
     SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING(called_function)
@@ -75,9 +85,13 @@ ZEND_NAMED_FUNCTION(scoutapm_curl_exec_handler)
     handler_index = handler_index_for_function(called_function);
 
 #if PHP_MAJOR_VERSION >= 8
-    recorded_arguments_index = find_index_for_recorded_arguments(unique_class_instance_id(zid));
+    class_instance_id = unique_class_instance_id(zid);
+    recorded_arguments_index = find_index_for_recorded_arguments(class_instance_id);
+    free((void*) class_instance_id);
 #else
-    recorded_arguments_index = find_index_for_recorded_arguments(unique_resource_id(SCOUT_WRAPPER_TYPE_CURL, zid));
+    resource_id = unique_resource_id(SCOUT_WRAPPER_TYPE_CURL, zid);
+    recorded_arguments_index = find_index_for_recorded_arguments(resource_id);
+    free((void*) resource_id);
 #endif
 
     if (recorded_arguments_index < 0) {

--- a/scout_curl_wrapper.c
+++ b/scout_curl_wrapper.c
@@ -19,12 +19,13 @@ ZEND_NAMED_FUNCTION(scoutapm_curl_setopt_handler)
 {
     zval *zid, *zvalue;
     zend_long options;
+    const char *passthru_function_name;
 
 #if PHP_MAJOR_VERSION >= 8
     ASSIGN_CURL_HANDLE_CLASS_ENTRY
 #endif
 
-    SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING()
+    SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING(passthru_function_name)
 
     ZEND_PARSE_PARAMETERS_START(3, 3)
 #if PHP_MAJOR_VERSION >= 8
@@ -44,7 +45,7 @@ ZEND_NAMED_FUNCTION(scoutapm_curl_setopt_handler)
 #endif
     }
 
-    SCOUT_INTERNAL_FUNCTION_PASSTHRU();
+    SCOUT_INTERNAL_FUNCTION_PASSTHRU(passthru_function_name);
 }
 
 ZEND_NAMED_FUNCTION(scoutapm_curl_exec_handler)
@@ -59,7 +60,7 @@ ZEND_NAMED_FUNCTION(scoutapm_curl_exec_handler)
     ASSIGN_CURL_HANDLE_CLASS_ENTRY
 #endif
 
-    SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING()
+    SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING(called_function)
 
     called_function = determine_function_name(execute_data);
 
@@ -80,6 +81,7 @@ ZEND_NAMED_FUNCTION(scoutapm_curl_exec_handler)
 #endif
 
     if (recorded_arguments_index < 0) {
+        free((void*) called_function);
         scoutapm_default_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
         return;
     }
@@ -93,5 +95,6 @@ ZEND_NAMED_FUNCTION(scoutapm_curl_exec_handler)
         SCOUTAPM_G(disconnected_call_argument_store)[recorded_arguments_index].argc,
         SCOUTAPM_G(disconnected_call_argument_store)[recorded_arguments_index].argv
     );
+    free((void*) called_function);
 }
 #endif

--- a/scout_execute_ex.c
+++ b/scout_execute_ex.c
@@ -90,6 +90,7 @@ void scoutapm_execute_internal(zend_execute_data *execute_data, zval *return_val
     function_name = determine_function_name(execute_data);
 
     if (should_be_instrumented(function_name, NULL) == 0) {
+        free((void*) function_name);
         if (original_zend_execute_internal) {
             original_zend_execute_internal(execute_data, return_value);
         } else {
@@ -112,6 +113,7 @@ void scoutapm_execute_internal(zend_execute_data *execute_data, zval *return_val
 
     record_observed_stack_frame(function_name, entered, scoutapm_microtime(), argc, argv);
     SCOUTAPM_G(currently_instrumenting) = 0;
+    free((void*) function_name);
 }
 
 void scoutapm_execute_ex(zend_execute_data *execute_data)
@@ -132,6 +134,7 @@ void scoutapm_execute_ex(zend_execute_data *execute_data)
     function_name = determine_function_name(execute_data);
 
     if (should_be_instrumented(function_name, NULL) == 0) {
+        free((void*) function_name);
         original_zend_execute_ex(execute_data);
         return;
     }
@@ -146,6 +149,7 @@ void scoutapm_execute_ex(zend_execute_data *execute_data)
 
     record_observed_stack_frame(function_name, entered, scoutapm_microtime(), argc, argv);
     SCOUTAPM_G(currently_instrumenting) = 0;
+    free((void*) function_name);
 }
 
 #endif /* SCOUTAPM_INSTRUMENT_USING_OBSERVER_API */

--- a/scout_file_wrapper.c
+++ b/scout_file_wrapper.c
@@ -12,7 +12,7 @@ ZEND_NAMED_FUNCTION(scoutapm_fopen_handler)
 {
     zend_string *filename, *mode;
     zval argv[2];
-    const char *passthru_function_name;
+    const char *passthru_function_name, *resource_id;
 
     SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING(passthru_function_name)
 
@@ -27,7 +27,9 @@ ZEND_NAMED_FUNCTION(scoutapm_fopen_handler)
     SCOUT_INTERNAL_FUNCTION_PASSTHRU(passthru_function_name);
 
     if (Z_TYPE_P(return_value) == IS_RESOURCE) {
-        record_arguments_for_call(unique_resource_id(SCOUT_WRAPPER_TYPE_FILE, return_value), 2, argv);
+        resource_id = unique_resource_id(SCOUT_WRAPPER_TYPE_FILE, return_value);
+        record_arguments_for_call(resource_id, 2, argv);
+        free((void*) resource_id);
     }
 }
 
@@ -36,7 +38,7 @@ ZEND_NAMED_FUNCTION(scoutapm_fread_handler)
     int handler_index;
     double entered = scoutapm_microtime();
     zval *resource_id;
-    const char *called_function;
+    const char *called_function, *str_resource_id;
     zend_long recorded_arguments_index;
 
     SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING(called_function)
@@ -49,7 +51,9 @@ ZEND_NAMED_FUNCTION(scoutapm_fread_handler)
 
     handler_index = handler_index_for_function(called_function);
 
-    recorded_arguments_index = find_index_for_recorded_arguments(unique_resource_id(SCOUT_WRAPPER_TYPE_FILE, resource_id));
+    str_resource_id = unique_resource_id(SCOUT_WRAPPER_TYPE_FILE, resource_id);
+    recorded_arguments_index = find_index_for_recorded_arguments(str_resource_id);
+    free((void*) str_resource_id);
 
     if (recorded_arguments_index < 0) {
         free((void*) called_function);
@@ -74,7 +78,7 @@ ZEND_NAMED_FUNCTION(scoutapm_fwrite_handler)
     int handler_index;
     double entered = scoutapm_microtime();
     zval *resource_id;
-    const char *called_function;
+    const char *called_function, *str_resource_id;
     zend_long recorded_arguments_index;
 
     SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING(called_function)
@@ -87,7 +91,9 @@ ZEND_NAMED_FUNCTION(scoutapm_fwrite_handler)
 
     handler_index = handler_index_for_function(called_function);
 
-    recorded_arguments_index = find_index_for_recorded_arguments(unique_resource_id(SCOUT_WRAPPER_TYPE_FILE, resource_id));
+    str_resource_id = unique_resource_id(SCOUT_WRAPPER_TYPE_FILE, resource_id);
+    recorded_arguments_index = find_index_for_recorded_arguments(str_resource_id);
+    free((void*) str_resource_id);
 
     if (recorded_arguments_index < 0) {
         free((void*) called_function);

--- a/scout_file_wrapper.c
+++ b/scout_file_wrapper.c
@@ -11,7 +11,7 @@
 ZEND_NAMED_FUNCTION(scoutapm_fopen_handler)
 {
     zend_string *filename, *mode;
-    zval *argv;
+    zval argv[2];
 
     SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING()
 
@@ -20,7 +20,6 @@ ZEND_NAMED_FUNCTION(scoutapm_fopen_handler)
             Z_PARAM_STR(mode)
     ZEND_PARSE_PARAMETERS_END();
 
-    argv = calloc(2, sizeof(zval));
     ZVAL_STR(&argv[0], filename);
     ZVAL_STR(&argv[1], mode);
 

--- a/scout_file_wrapper.c
+++ b/scout_file_wrapper.c
@@ -12,8 +12,9 @@ ZEND_NAMED_FUNCTION(scoutapm_fopen_handler)
 {
     zend_string *filename, *mode;
     zval argv[2];
+    const char *passthru_function_name;
 
-    SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING()
+    SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING(passthru_function_name)
 
     ZEND_PARSE_PARAMETERS_START(2, 4)
             Z_PARAM_STR(filename)
@@ -23,7 +24,7 @@ ZEND_NAMED_FUNCTION(scoutapm_fopen_handler)
     ZVAL_STR(&argv[0], filename);
     ZVAL_STR(&argv[1], mode);
 
-    SCOUT_INTERNAL_FUNCTION_PASSTHRU();
+    SCOUT_INTERNAL_FUNCTION_PASSTHRU(passthru_function_name);
 
     if (Z_TYPE_P(return_value) == IS_RESOURCE) {
         record_arguments_for_call(unique_resource_id(SCOUT_WRAPPER_TYPE_FILE, return_value), 2, argv);
@@ -38,7 +39,7 @@ ZEND_NAMED_FUNCTION(scoutapm_fread_handler)
     const char *called_function;
     zend_long recorded_arguments_index;
 
-    SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING()
+    SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING(called_function)
 
     called_function = determine_function_name(execute_data);
 
@@ -51,6 +52,7 @@ ZEND_NAMED_FUNCTION(scoutapm_fread_handler)
     recorded_arguments_index = find_index_for_recorded_arguments(unique_resource_id(SCOUT_WRAPPER_TYPE_FILE, resource_id));
 
     if (recorded_arguments_index < 0) {
+        free((void*) called_function);
         scoutapm_default_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
         return;
     }
@@ -64,6 +66,7 @@ ZEND_NAMED_FUNCTION(scoutapm_fread_handler)
         SCOUTAPM_G(disconnected_call_argument_store)[recorded_arguments_index].argc,
         SCOUTAPM_G(disconnected_call_argument_store)[recorded_arguments_index].argv
     );
+    free((void*) called_function);
 }
 
 ZEND_NAMED_FUNCTION(scoutapm_fwrite_handler)
@@ -74,7 +77,7 @@ ZEND_NAMED_FUNCTION(scoutapm_fwrite_handler)
     const char *called_function;
     zend_long recorded_arguments_index;
 
-    SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING()
+    SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING(called_function)
 
     called_function = determine_function_name(execute_data);
 
@@ -87,6 +90,7 @@ ZEND_NAMED_FUNCTION(scoutapm_fwrite_handler)
     recorded_arguments_index = find_index_for_recorded_arguments(unique_resource_id(SCOUT_WRAPPER_TYPE_FILE, resource_id));
 
     if (recorded_arguments_index < 0) {
+        free((void*) called_function);
         scoutapm_default_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
         return;
     }
@@ -100,4 +104,5 @@ ZEND_NAMED_FUNCTION(scoutapm_fwrite_handler)
         SCOUTAPM_G(disconnected_call_argument_store)[recorded_arguments_index].argc,
         SCOUTAPM_G(disconnected_call_argument_store)[recorded_arguments_index].argv
     );
+    free((void*) called_function);
 }

--- a/scout_internal_handlers.c
+++ b/scout_internal_handlers.c
@@ -173,7 +173,7 @@ ZEND_NAMED_FUNCTION(scoutapm_default_handler)
     zval *argv = NULL;
     const char *called_function;
 
-    SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING()
+    SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING(called_function)
 
     /* note - no strdup needed as we copy it in record_observed_stack_frame */
     called_function = determine_function_name(execute_data);
@@ -187,6 +187,7 @@ ZEND_NAMED_FUNCTION(scoutapm_default_handler)
     original_handlers[handler_index](INTERNAL_FUNCTION_PARAM_PASSTHRU);
 
     record_observed_stack_frame(called_function, entered, scoutapm_microtime(), argc, argv);
+    free((void*) called_function);
 }
 
 int unchecked_handler_index_for_function(const char *function_to_lookup)

--- a/scout_internal_handlers.h
+++ b/scout_internal_handlers.h
@@ -42,13 +42,16 @@ typedef struct _handler_lookup {
 /* overload an instance class method by wrapping its handler with our own handler */
 #define SCOUT_OVERLOAD_METHOD(lowercase_class_name, method_name, handler_to_use) SCOUT_OVERLOAD_CLASS_ENTRY_FUNCTION(lowercase_class_name, "->", method_name, handler_to_use)
 
-#define SCOUT_INTERNAL_FUNCTION_PASSTHRU() original_handlers[handler_index_for_function(determine_function_name(execute_data))](INTERNAL_FUNCTION_PARAM_PASSTHRU)
+#define SCOUT_INTERNAL_FUNCTION_PASSTHRU(macro_pt_func_name) \
+    macro_pt_func_name = determine_function_name(execute_data); \
+    original_handlers[handler_index_for_function(macro_pt_func_name)](INTERNAL_FUNCTION_PARAM_PASSTHRU); \
+    free((void *) (macro_pt_func_name))
 
-#define SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING()      \
-    if (SCOUTAPM_G(all_instrumentation_enabled) != 1   \
-        || SCOUTAPM_G(currently_instrumenting) == 1) { \
-        SCOUT_INTERNAL_FUNCTION_PASSTHRU();            \
-        return;                                        \
+#define SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING(macro_pt_func_name)      \
+    if (SCOUTAPM_G(all_instrumentation_enabled) != 1            \
+        || SCOUTAPM_G(currently_instrumenting) == 1) {          \
+        SCOUT_INTERNAL_FUNCTION_PASSTHRU(macro_pt_func_name); \
+        return;                                                 \
     }
 
 #endif /* SCOUT_INTERNAL_HANDLERS_H */

--- a/scout_pdo_wrapper.c
+++ b/scout_pdo_wrapper.c
@@ -11,7 +11,7 @@
 ZEND_NAMED_FUNCTION(scoutapm_pdo_prepare_handler)
 {
     zval *statement;
-    const char *passthru_function_name;
+    const char *passthru_function_name, *class_instance_id;
 
     SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING(passthru_function_name)
 
@@ -25,14 +25,16 @@ ZEND_NAMED_FUNCTION(scoutapm_pdo_prepare_handler)
         return;
     }
 
-    record_arguments_for_call(unique_class_instance_id(return_value), 1, statement);
+    class_instance_id = unique_class_instance_id(return_value);
+    record_arguments_for_call(class_instance_id, 1, statement);
+    free((void*) class_instance_id);
 }
 
 ZEND_NAMED_FUNCTION(scoutapm_pdostatement_execute_handler)
 {
     int handler_index;
     double entered = scoutapm_microtime();
-    const char *called_function;
+    const char *called_function, *class_instance_id;
     zend_long recorded_arguments_index;
 
     SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING(called_function)
@@ -41,7 +43,9 @@ ZEND_NAMED_FUNCTION(scoutapm_pdostatement_execute_handler)
 
     handler_index = handler_index_for_function(called_function);
 
-    recorded_arguments_index = find_index_for_recorded_arguments(unique_class_instance_id(getThis()));
+    class_instance_id = unique_class_instance_id(getThis());
+    recorded_arguments_index = find_index_for_recorded_arguments(class_instance_id);
+    free((void*) class_instance_id);
 
     if (recorded_arguments_index < 0) {
         free((void*) called_function);

--- a/scout_pdo_wrapper.c
+++ b/scout_pdo_wrapper.c
@@ -11,14 +11,15 @@
 ZEND_NAMED_FUNCTION(scoutapm_pdo_prepare_handler)
 {
     zval *statement;
+    const char *passthru_function_name;
 
-    SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING()
+    SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING(passthru_function_name)
 
     ZEND_PARSE_PARAMETERS_START(1, 10)
         Z_PARAM_ZVAL(statement)
     ZEND_PARSE_PARAMETERS_END();
 
-    SCOUT_INTERNAL_FUNCTION_PASSTHRU();
+    SCOUT_INTERNAL_FUNCTION_PASSTHRU(passthru_function_name);
 
     if (Z_TYPE_P(return_value) != IS_OBJECT) {
         return;
@@ -34,7 +35,7 @@ ZEND_NAMED_FUNCTION(scoutapm_pdostatement_execute_handler)
     const char *called_function;
     zend_long recorded_arguments_index;
 
-    SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING()
+    SCOUT_PASSTHRU_IF_ALREADY_INSTRUMENTING(called_function)
 
     called_function = determine_function_name(execute_data);
 
@@ -43,6 +44,7 @@ ZEND_NAMED_FUNCTION(scoutapm_pdostatement_execute_handler)
     recorded_arguments_index = find_index_for_recorded_arguments(unique_class_instance_id(getThis()));
 
     if (recorded_arguments_index < 0) {
+        free((void*) called_function);
         scoutapm_default_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
         return;
     }
@@ -56,4 +58,5 @@ ZEND_NAMED_FUNCTION(scoutapm_pdostatement_execute_handler)
         SCOUTAPM_G(disconnected_call_argument_store)[recorded_arguments_index].argc,
         SCOUTAPM_G(disconnected_call_argument_store)[recorded_arguments_index].argv
     );
+    free((void*) called_function);
 }

--- a/scout_utils.c
+++ b/scout_utils.c
@@ -12,6 +12,8 @@
  * Given some zend_execute_data, figure out what the function/method/static method is being called. The convention used
  * is `ClassName::methodName` for static methods, `ClassName->methodName` for instance methods, and `functionName` for
  * regular functions.
+ *
+ * Result must ALWAYS be free'd, or you'll leak memory.
  */
 const char* determine_function_name(zend_execute_data *execute_data)
 {
@@ -19,7 +21,7 @@ const char* determine_function_name(zend_execute_data *execute_data)
     char *ret;
 
     if (!execute_data->func) {
-        return "<not a function call>";
+        return strdup("<not a function call>");
     }
 
     if (execute_data->func->common.fn_flags & ZEND_ACC_STATIC) {
@@ -38,7 +40,7 @@ const char* determine_function_name(zend_execute_data *execute_data)
         return ret;
     }
 
-    return ZSTR_VAL(execute_data->func->common.function_name);
+    return strdup(ZSTR_VAL(execute_data->func->common.function_name));
 }
 
 /*

--- a/tests/bug-88.phpt
+++ b/tests/bug-88.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Bug https://github.com/scoutapp/scout-apm-php-ext/issues/88 - memory usage should not increase when no instrumentation happens
+--SKIPIF--
+<?php if (!extension_loaded("scoutapm")) die("skip scoutapm extension required."); ?>
+--FILE--
+<?php
+
+class A {
+  function b() {}
+}
+
+$a = new A();
+
+scoutapm_enable_instrumentation(true);
+
+$before = (int) (exec("ps --pid " . getmypid() . " --no-headers -o rss"));
+for ($i = 0; $i <= 10000000; $i++) {
+    $a->b();
+}
+$after = (int) (exec("ps --pid " . getmypid() . " --no-headers -o rss"));
+
+echo "Before & after:\n";
+var_dump($before, $after);
+
+echo "Difference:\n";
+var_dump($after - $before);
+
+$threshold = 500; // bytes
+echo "Within $threshold bytes limit:\n";
+var_dump(($after - $before) < $threshold);
+
+?>
+--EXPECTF--
+Before & after:
+int(%d)
+int(%d)
+Difference:
+int(%d)
+Within %d bytes limit:
+bool(true)

--- a/zend_scoutapm.h
+++ b/zend_scoutapm.h
@@ -21,7 +21,7 @@
 #include "scout_execute_ex.h"
 
 #define PHP_SCOUTAPM_NAME "scoutapm"
-#define PHP_SCOUTAPM_VERSION "1.4.0"
+#define PHP_SCOUTAPM_VERSION "1.4.1"
 
 /* Extreme amounts of debugging, set to 1 to enable it and `make clean && make` (tests will fail...) */
 #define SCOUT_APM_EXT_DEBUGGING 0

--- a/zend_scoutapm.h
+++ b/zend_scoutapm.h
@@ -76,7 +76,10 @@ typedef void (*zif_handler)(INTERNAL_FUNCTION_PARAMETERS);
 #define SCOUTAPM_DEBUG_MESSAGE(...) /**/
 #endif
 
-/* Shortcut defined to allow using a `char *` with snprintf - determine the size first, allocate, then snprintf */
+/*
+ * Shortcut defined to allow using a `char *` with snprintf - determine the size first, allocate, then snprintf
+ * NOTE: When using this macro, the destString must ALWAYS be freed!
+ */
 #define DYNAMIC_MALLOC_SPRINTF(destString, sizeNeeded, fmt, ...) \
     sizeNeeded = snprintf(NULL, 0, fmt, ##__VA_ARGS__) + 1; \
     destString = (char*)malloc(sizeNeeded); \


### PR DESCRIPTION
Un-freed usages of `DYNAMIC_MALLOC_SPRINTF` were popping up a lot, especially due to `determine_function_name`. This change now correctly frees anywhere this macro is used to stop memory leaking.

Fixes #88 