### PR TITLE
Fixing more missed free calls in PHP 8 only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.4.2 - 2021-06-29
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#92](https://github.com/scoutapp/scout-apm-php-ext/pull/92) Fixed some missed free calls after DYNAMIC_MALLOC_SPRINTF usage in PHP 8 only
+
 ## 1.4.1 - 2021-06-29
 
 ### Added

--- a/package.xml
+++ b/package.xml
@@ -26,10 +26,10 @@
 
     <!-- Current Release -->
     <date>2021-06-29</date>
-    <time>12:00:00</time>
+    <time>13:00:00</time>
     <version>
-        <release>1.4.1</release>
-        <api>1.4.1</api>
+        <release>1.4.2</release>
+        <api>1.4.2</api>
     </version>
     <stability>
         <release>stable</release>
@@ -37,7 +37,7 @@
     </stability>
     <license uri="https://opensource.org/licenses/MIT">MIT</license>
     <notes>
-        - Fixed memory leaks from DYNAMIC_MALLOC_SPRINTF un-freed usages (#91)
+        - Fixed some missed free calls after DYNAMIC_MALLOC_SPRINTF usage in PHP 8 only (#92)
     </notes>
     <!-- End Current Release -->
 
@@ -110,6 +110,22 @@
     <zendextsrcrelease />
 
     <changelog>
+        <release>
+            <date>2021-06-29</date>
+            <time>12:00:00</time>
+            <version>
+                <release>1.4.1</release>
+                <api>1.4.1</api>
+            </version>
+            <stability>
+                <release>stable</release>
+                <api>stable</api>
+            </stability>
+            <license uri="https://opensource.org/licenses/MIT">MIT</license>
+            <notes>
+                - Fixed memory leaks from DYNAMIC_MALLOC_SPRINTF un-freed usages (#91)
+            </notes>
+        </release>
         <release>
             <date>2021-06-17</date>
             <time>16:00:00</time>

--- a/scout_observer.c
+++ b/scout_observer.c
@@ -92,6 +92,8 @@ static void scout_observer_end(zend_execute_data *execute_data, zval *return_val
     record_observed_stack_frame(function_name, SCOUTAPM_G(observer_api_start_time), scoutapm_microtime(), argc, argv);
     SCOUTAPM_G(currently_instrumenting) = 0;
     SCOUTAPM_G(observer_api_start_time) = 0;
+
+    free((void*) function_name);
 }
 
 // Note: this is only called FIRST time each function is invoked (better that way)
@@ -109,8 +111,11 @@ zend_observer_fcall_handlers scout_observer_api_register(zend_execute_data *exec
 
     // Can only resolve magic method name at call-time with Observer API, so pass NULL for the magic method name
     if (should_be_instrumented(function_name, NULL) == 0) {
+        free((void*) function_name);
         return handlers;
     }
+
+    free((void*) function_name);
 
     handlers.begin = scout_observer_begin;
     handlers.end = scout_observer_end;

--- a/zend_scoutapm.h
+++ b/zend_scoutapm.h
@@ -21,7 +21,7 @@
 #include "scout_execute_ex.h"
 
 #define PHP_SCOUTAPM_NAME "scoutapm"
-#define PHP_SCOUTAPM_VERSION "1.4.1"
+#define PHP_SCOUTAPM_VERSION "1.4.2"
 
 /* Extreme amounts of debugging, set to 1 to enable it and `make clean && make` (tests will fail...) */
 #define SCOUT_APM_EXT_DEBUGGING 0


### PR DESCRIPTION
After fixing #88 and releasing 1.4.1 I spotted some additional free() calls that were missed from the `DYNAMIC_MALLOC_SPRINTF` macro usage.

These were not covered because "find usages" feature in CLion did not detect usages that were hidden by preprocessor directives and I had only compiled (locally) against PHP 7.1.

In practice, the impact on PHP 8 should be minimal, since the Observer API is much more efficient, however a bug is a bug, and should be fixed.
