### PR TITLE
Add method capture for HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.5.0 - 2021-12-23
+
+### Added
+
+- [#96](https://github.com/scoutapp/scout-apm-php-ext/pull/96) file_get_contents and curl_exec now record HTTP methods
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 1.4.3 - 2021-10-29
 
 ### Added

--- a/package.xml
+++ b/package.xml
@@ -25,11 +25,11 @@
     </lead>
 
     <!-- Current Release -->
-    <date>2021-10-29</date>
+    <date>2021-12-23</date>
     <time>09:00:00</time>
     <version>
-        <release>1.4.3</release>
-        <api>1.4.3</api>
+        <release>1.5.0</release>
+        <api>1.5.0</api>
     </version>
     <stability>
         <release>stable</release>
@@ -37,7 +37,7 @@
     </stability>
     <license uri="https://opensource.org/licenses/MIT">MIT</license>
     <notes>
-        - Fixed segfault when static anonymous functions are called (#94)
+        - file_get_contents and curl_exec now record HTTP methods (#96)
     </notes>
     <!-- End Current Release -->
 
@@ -114,6 +114,22 @@
     <zendextsrcrelease />
 
     <changelog>
+        <release>
+            <date>2021-10-29</date>
+            <time>09:00:00</time>
+            <version>
+                <release>1.4.3</release>
+                <api>1.4.3</api>
+            </version>
+            <stability>
+                <release>stable</release>
+                <api>stable</api>
+            </stability>
+            <license uri="https://opensource.org/licenses/MIT">MIT</license>
+            <notes>
+                - Fixed segfault when static anonymous functions are called (#94)
+            </notes>
+        </release>
         <release>
             <date>2021-06-29</date>
             <time>13:00:00</time>

--- a/package.xml
+++ b/package.xml
@@ -86,6 +86,8 @@
                 <file name="016-memcached-support.phpt" role="test" />
                 <file name="017-elastic-support.phpt" role="test" />
                 <file name="018-do-not-instrument-by-default.phpt" role="test" />
+                <file name="019-url-method-capture-fgc.phpt" role="test" />
+                <file name="020-url-method-capture-curl.phpt" role="test" />
                 <file name="bug-47.phpt" role="test" />
                 <file name="bug-49.phpt" role="test" />
                 <file name="bug-55.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -87,7 +87,8 @@
                 <file name="017-elastic-support.phpt" role="test" />
                 <file name="018-do-not-instrument-by-default.phpt" role="test" />
                 <file name="019-url-method-capture-fgc.phpt" role="test" />
-                <file name="020-url-method-capture-curl.phpt" role="test" />
+                <file name="020-url-method-capture-curl-post.phpt" role="test" />
+                <file name="020-url-method-capture-curl-customreq.phpt" role="test" />
                 <file name="bug-47.phpt" role="test" />
                 <file name="bug-49.phpt" role="test" />
                 <file name="bug-55.phpt" role="test" />

--- a/scout_curl_wrapper.c
+++ b/scout_curl_wrapper.c
@@ -17,6 +17,7 @@
 
 #define SCOUTAPM_CURLOPT_URL "CURLOPT_URL"
 #define SCOUTAPM_CURLOPT_POST "CURLOPT_POST"
+#define SCOUTAPM_CURLOPT_CUSTOMREQUEST "CURLOPT_CUSTOMREQUEST"
 
 #define SCOUTAPM_CURL_GET_CURLOPT_ADD_TO_ARGV(opt) \
     recorded_arguments_index = scout_curl_get_curlopt(zid, opt); \
@@ -100,6 +101,9 @@ ZEND_NAMED_FUNCTION(scoutapm_curl_setopt_handler)
     if (options == CURLOPT_POST) {
         scout_curl_store_curlopt(zid, SCOUTAPM_CURLOPT_POST, zvalue);
     }
+    if (options == CURLOPT_CUSTOMREQUEST) {
+        scout_curl_store_curlopt(zid, SCOUTAPM_CURLOPT_CUSTOMREQUEST, zvalue);
+    }
 
     SCOUT_INTERNAL_FUNCTION_PASSTHRU(passthru_function_name);
 }
@@ -133,6 +137,7 @@ ZEND_NAMED_FUNCTION(scoutapm_curl_exec_handler)
 
     SCOUTAPM_CURL_GET_CURLOPT_ADD_TO_ARGV(SCOUTAPM_CURLOPT_URL);
     SCOUTAPM_CURL_GET_CURLOPT_ADD_TO_ARGV(SCOUTAPM_CURLOPT_POST);
+    SCOUTAPM_CURL_GET_CURLOPT_ADD_TO_ARGV(SCOUTAPM_CURLOPT_CUSTOMREQUEST);
 
     original_handlers[handler_index](INTERNAL_FUNCTION_PARAM_PASSTHRU);
 

--- a/scout_utils.c
+++ b/scout_utils.c
@@ -91,6 +91,7 @@ reference_retry_point:
                 if (stream_context != NULL) {
                     smart_str json_encode_string_buffer = {0};
                     php_json_encode(&json_encode_string_buffer, &stream_context->options, 0);
+                    smart_str_0(&json_encode_string_buffer);
                     ZVAL_STR_COPY(destination, json_encode_string_buffer.s);
                     smart_str_free(&json_encode_string_buffer);
                     return;

--- a/tests/009-curl_exec.phpt
+++ b/tests/009-curl_exec.phpt
@@ -30,7 +30,9 @@ float(%f)
 float(%f)
 float(%f)
 bool(true)
-array(1) {
+array(%d) {
   [0]=>
   string(%d) "file://%s/tests/009-curl_exec.php"
+  [1]=>
+  NULL
 }

--- a/tests/019-url-method-capture-fgc.phpt
+++ b/tests/019-url-method-capture-fgc.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Both URL and Method can be captured using file_get_contents
+--SKIPIF--
+<?php if (!extension_loaded("scoutapm")) die("skip scoutapm extension required."); ?>
+--FILE--
+<?php
+
+var_dump(in_array('file_get_contents', scoutapm_list_instrumented_functions()));
+scoutapm_enable_instrumentation(true);
+
+@file_get_contents(
+    'https://scoutapm.com/robots.txt',
+    false,
+    stream_context_create([
+        'http' => [
+            'method' => 'POST',
+            'header' => [
+                'User-Agent: scoutapp/scout-apm-php-ext Test Suite FGC',
+            ],
+        ],
+    ])
+);
+$call = scoutapm_get_calls()[0];
+
+var_dump($call['function']);
+var_dump($call['argv'][0]);
+var_dump(json_decode($call['argv'][2], true)['http']['method']);
+?>
+--EXPECTF--
+bool(true)
+string(%d) "file_get_contents"
+string(%d) "https://scoutapm.com/robots.txt"
+string(%d) "POST"

--- a/tests/020-url-method-capture-curl-post.phpt
+++ b/tests/020-url-method-capture-curl-post.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Both URL and Method can be captured using curl
+Both URL and Method can be captured using curl + CURLOPT_POST
 --SKIPIF--
 <?php if (!extension_loaded("scoutapm")) die("skip scoutapm extension required."); ?>
 <?php if (!extension_loaded("curl")) die("skip curl extension required."); ?>
@@ -29,4 +29,6 @@ array(%d) {
   string(%d) "https://scoutapm.com/robots.txt"
   [%d]=>
   bool(true)
+  [%d]=>
+  NULL
 }

--- a/tests/020-url-method-capture-curl.phpt
+++ b/tests/020-url-method-capture-curl.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Both URL and Method can be captured using file_get_contents
+--SKIPIF--
+skip not implemented yet
+<?php if (!extension_loaded("scoutapm")) die("skip scoutapm extension required."); ?>
+<?php if (!extension_loaded("curl")) die("skip curl extension required."); ?>
+--FILE--
+<?php
+
+var_dump(in_array('curl_exec', scoutapm_list_instrumented_functions()));
+scoutapm_enable_instrumentation(true);
+
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, "https://scoutapm.com/robots.txt");
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+curl_setopt($ch, CURLOPT_POST, 1);
+curl_setopt($ch, CURLOPT_USERAGENT, 'scoutapp/scout-apm-php-ext Test Suite curl');
+curl_exec($ch);
+
+$call = scoutapm_get_calls()[0];
+
+var_dump($call['function']);
+var_dump($call['argv']);
+?>
+--EXPECTF--
+bool(true)
+string(9) "curl_exec"
+array(%d) {
+  [%d]=>
+  string(%d) "https://scoutapm.com/robots.txt"
+  [%d]=>
+  string(%d) "POST"
+}

--- a/tests/020-url-method-capture-curl.phpt
+++ b/tests/020-url-method-capture-curl.phpt
@@ -1,7 +1,6 @@
 --TEST--
-Both URL and Method can be captured using file_get_contents
+Both URL and Method can be captured using curl
 --SKIPIF--
-skip not implemented yet
 <?php if (!extension_loaded("scoutapm")) die("skip scoutapm extension required."); ?>
 <?php if (!extension_loaded("curl")) die("skip curl extension required."); ?>
 --FILE--
@@ -13,7 +12,7 @@ scoutapm_enable_instrumentation(true);
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_URL, "https://scoutapm.com/robots.txt");
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-curl_setopt($ch, CURLOPT_POST, 1);
+curl_setopt($ch, CURLOPT_POST, true);
 curl_setopt($ch, CURLOPT_USERAGENT, 'scoutapp/scout-apm-php-ext Test Suite curl');
 curl_exec($ch);
 
@@ -29,5 +28,5 @@ array(%d) {
   [%d]=>
   string(%d) "https://scoutapm.com/robots.txt"
   [%d]=>
-  string(%d) "POST"
+  bool(true)
 }

--- a/tests/021-url-method-capture-curl-customreq.phpt
+++ b/tests/021-url-method-capture-curl-customreq.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Calls to curl_exec are logged
+Both URL and Method can be captured using curl + CURLOPT_CUSTOMREQUEST
 --SKIPIF--
 <?php if (!extension_loaded("scoutapm")) die("skip scoutapm extension required."); ?>
 <?php if (!extension_loaded("curl")) die("skip curl extension required."); ?>
@@ -10,31 +10,25 @@ var_dump(in_array('curl_exec', scoutapm_list_instrumented_functions()));
 scoutapm_enable_instrumentation(true);
 
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, "file://" . __FILE__);
+curl_setopt($ch, CURLOPT_URL, "https://scoutapm.com/robots.txt");
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+curl_setopt($ch, CURLOPT_USERAGENT, 'scoutapp/scout-apm-php-ext Test Suite curl');
 curl_exec($ch);
 
 $call = scoutapm_get_calls()[0];
 
 var_dump($call['function']);
-var_dump($call['entered']);
-var_dump($call['exited']);
-var_dump($call['time_taken']);
-var_dump($call['exited'] > $call['entered']);
 var_dump($call['argv']);
 ?>
 --EXPECTF--
 bool(true)
 string(9) "curl_exec"
-float(%f)
-float(%f)
-float(%f)
-bool(true)
 array(%d) {
   [%d]=>
-  string(%d) "file://%s/tests/009-curl_exec.php"
+  string(%d) "https://scoutapm.com/robots.txt"
   [%d]=>
   NULL
   [%d]=>
-  NULL
+  string(%d) "POST"
 }

--- a/zend_scoutapm.h
+++ b/zend_scoutapm.h
@@ -21,7 +21,7 @@
 #include "scout_execute_ex.h"
 
 #define PHP_SCOUTAPM_NAME "scoutapm"
-#define PHP_SCOUTAPM_VERSION "1.4.3"
+#define PHP_SCOUTAPM_VERSION "1.5.0"
 
 /* Extreme amounts of debugging, set to 1 to enable it and `make clean && make` (tests will fail...) */
 #define SCOUT_APM_EXT_DEBUGGING 0


### PR DESCRIPTION
Added ability to log HTTP method used when calling:

 * `file_get_contents`
 * `curl_exec` when using `CURLOPT_CUSTOMREQUEST` option
 * `curl_exec` when using `CURLOPT_POST` option