### PR TITLE
Added release automation

### DIFF
--- a/.github/workflows/release-on-milestone-closed-triggering-release-event.yml
+++ b/.github/workflows/release-on-milestone-closed-triggering-release-event.yml
@@ -1,0 +1,61 @@
+# Alternate workflow example.
+# This one is identical to the one in release-on-milestone.yml, with one change:
+# the Release step uses the ORGANIZATION_ADMIN_TOKEN instead, to allow it to
+# trigger a release workflow event. This is useful if you have other actions
+# that intercept that event.
+
+name: "Automatic Releases"
+
+on:
+  milestone:
+    types:
+      - "closed"
+
+jobs:
+  release:
+    name: "GIT tag, release & create merge-up PR"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+
+      - name: "Release"
+        uses: "laminas/automatic-releases@v1"
+        with:
+          command-name: "laminas:automatic-releases:release"
+        env:
+          "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
+          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
+          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
+          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
+
+      - name: "Create Merge-Up Pull Request"
+        uses: "laminas/automatic-releases@v1"
+        with:
+          command-name: "laminas:automatic-releases:create-merge-up-pull-request"
+        env:
+          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
+          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
+          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
+
+      - name: "Create and/or Switch to new Release Branch"
+        uses: "laminas/automatic-releases@v1"
+        with:
+          command-name: "laminas:automatic-releases:switch-default-branch-to-next-minor"
+        env:
+          "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
+          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
+          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
+          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
+
+      - name: "Create new milestones"
+        uses: "laminas/automatic-releases@v1"
+        with:
+          command-name: "laminas:automatic-releases:create-milestones"
+        env:
+          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
+          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
+          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}

--- a/.github/workflows/release-on-milestone-closed-triggering-release-event.yml
+++ b/.github/workflows/release-on-milestone-closed-triggering-release-event.yml
@@ -111,3 +111,34 @@ jobs:
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
+
+      ####################################################
+      ################ POST RELEASE ASSET ################
+      ####################################################
+
+      - name: Setup PHP with PECL extension
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: "none"
+          php-version: "8.0"
+          tools: pecl
+      - name: "Build PECL Package"
+        run: pecl package
+      - name: "Fetch new release from Github API"
+        uses: octokit/request-action@v2.x
+        id: get_new_release
+        with:
+          route: GET /repos/{owner}/{repo}/releases/latest
+          owner: scoutapp
+          repo: scout-apm-php-ext
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Upload PECL package to latest release"
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ fromJson(steps.get_new_release.outputs.data).upload_url }}
+          asset_path: ./scoutapm-${{ fromJson(steps.get_new_release.outputs.data).tag_name }}.tgz
+          asset_name: scoutapm-${{ fromJson(steps.get_new_release.outputs.data).tag_name }}.tgz
+          asset_content_type: application/gzip

--- a/.github/workflows/release-on-milestone-closed-triggering-release-event.yml
+++ b/.github/workflows/release-on-milestone-closed-triggering-release-event.yml
@@ -20,6 +20,58 @@ jobs:
       - name: "Checkout"
         uses: "actions/checkout@v2"
 
+      #####################################################
+      ################ RELEASE PREPARATION ################
+      #####################################################
+
+      - name: "Fetch latest release tag from Github API"
+        uses: octokit/request-action@v2.x
+        id: get_latest_release
+        with:
+          route: GET /repos/{owner}/{repo}/releases/latest
+          owner: scoutapp
+          repo: scout-apm-php-ext
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Verify that PHP_SCOUTAPM_VERSION has been changed"
+        run: |
+          PREVIOUS_RELEASE="${{ fromJson(steps.get_latest_release.outputs.data).tag_name }}"
+          HEADER_RELEASE="$(cat zend_scoutapm.h | grep "PHP_SCOUTAPM_VERSION" | awk '{print $3}' | tr -d '"')"
+          echo "Previous release: $PREVIOUS_RELEASE"
+          echo "PHP_SCOUTAPM_VERSION in header: $HEADER_RELEASE"
+          if [[ "$PREVIOUS_RELEASE" = "$HEADER_RELEASE" ]]
+          then
+            echo "PHP_SCOUTAPM_VERSION in zend_scoutapm.h has NOT been changed, cannot release"
+            exit 1
+          else
+            echo "Version in zend_scoutapm.h HAS been changed."
+            exit 0
+          fi
+      - name: "Extract latest version from package.xml"
+        uses: QwerMike/xpath-action@v1
+        id: get_package_xml_version
+        with:
+          filename: 'package.xml'
+          expression: "//*[local-name()='package']/*[local-name()='version']/*[local-name()='release']/text()"
+      - name: "Check package.xml version release has been changed"
+        run: |
+          PREVIOUS_RELEASE="${{ fromJson(steps.get_latest_release.outputs.data).tag_name }}"
+          XML_RELEASE="${{ steps.get_package_xml_version.outputs.result }}"
+          echo "Previous release: $PREVIOUS_RELEASE"
+          echo "package.xml version: $XML_RELEASE"
+          if [[ "$PREVIOUS_RELEASE" = "$XML_RELEASE" ]]
+          then
+            echo "package.xml version has NOT been changed, cannot release"
+            exit 1
+          else
+            echo "Version in package.xml HAS been changed."
+            exit 0
+          fi
+
+      ####################################################
+      ################## ACTUAL RELEASE ##################
+      ####################################################
+
       - name: "Release"
         uses: "laminas/automatic-releases@v1"
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+# THE CHANGELOG HAS MOVED
+
+Please see [the releases page](https://github.com/scoutapp/scout-apm-php-ext/releases) for release 1.7.0 onwards.
+
 ## 1.6.0 - 2022-01-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -103,9 +103,6 @@ print_cvs
  - Rebuild from scratch (`full-clean.sh`, then build as above)
  - `make test` to ensure everything passes locally
  - Push the branch (optionally, make a PR to GitHub) to trigger CI to build
- - Once passed, `pecl package` to generate the tgz
- - Upload to `pecl.php.net`
- - Make a GPG-signed tag with `git tag -s <tagversion>` and enter changelog notes in tag body
- - `git push origin <tagversion>` to push the tag up
- - [Create a release](https://github.com/scoutapp/scout-apm-php-ext/releases/new) from the tag (use same changelog notes)
- - Shift the milestones along on GitHub
+ - Once merged, close the milestone to automatically release & generate the TGZ asset
+ - Go to [the latest release](https://github.com/scoutapp/scout-apm-php-ext/releases) just created
+ - Download the TGZ asset and upload it to `pecl.php.net`


### PR DESCRIPTION
Adds https://github.com/laminas/automatic-releases release automation

### NOTE - additional steps required:

**BEFORE RELEASE RUNS**

 - [x] Verify `package.xml` is updated + incremented from the last release
 - [x] ~Run `pecl package-validate` to verify it's valid~ (already done in main CI pipeline)
 - [x] Verify `PHP_SCOUTAPM_VERSION` is incremented from the last release

**AFTER RELEASE RUNS**

 - [x] Run `pecl package`
 - [x] Attach TGZ package to release