### PR TITLE
Add support for compiling on Windows

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup PHP SDK
         id: setup-php
-        uses: cmb69/setup-php-sdk@v0.1
+        uses: cmb69/setup-php-sdk@v0.5
         with:
           version: ${{matrix.version}}
           arch: ${{matrix.arch}}

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -6,24 +6,32 @@ on:
 
 jobs:
   windows-test:
-    name: "Build and test on Windows"
+    name: "Win PHPT"
     defaults:
       run:
         shell: cmd
     strategy:
       fail-fast: false
       matrix:
-        version: [ "8.1", "8.0", "7.4", "7.3", "7.2", "7.1" ]
+        os: [ windows-2019, windows-2022 ]
+        php: [ "8.1", "8.0", "7.4", "7.3", "7.2", "7.1" ]
         arch: [ x64, x86 ]
         ts: [ ts, nts ]
-    runs-on: windows-latest
+        exclude:
+          - { os: windows-2019, php: "8.1" }
+          - { os: windows-2019, php: "8.0" }
+          - { os: windows-2019, php: "7.4" }
+          - { os: windows-2019, php: "7.3" }
+          - { os: windows-2022, php: "7.2" }
+          - { os: windows-2022, php: "7.1" }
+    runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
       - name: Setup PHP SDK
         id: setup-php
         uses: cmb69/setup-php-sdk@v0.5
         with:
-          version: ${{matrix.version}}
+          version: ${{matrix.php}}
           arch: ${{matrix.arch}}
           ts: ${{matrix.ts}}
       - name: Enable Developer Command Prompt

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -5,6 +5,40 @@ on:
   pull_request:
 
 jobs:
+  windows-test:
+    name: "Build and test on Windows"
+    defaults:
+      run:
+        shell: cmd
+    strategy:
+      matrix:
+        version: [ "8.1" ]
+        arch: [ x64 ]
+        ts: [ ts ]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup PHP SDK
+        id: setup-php
+        uses: cmb69/setup-php-sdk@v0.1
+        with:
+          version: ${{matrix.version}}
+          arch: ${{matrix.arch}}
+          ts: ${{matrix.ts}}
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{matrix.arch}}
+          toolset: ${{steps.setup-php.outputs.toolset}}
+      - name: phpize
+        run: phpize
+      - name: configure
+        run: configure --enable-scoutapm --with-prefix=${{steps.setup-php.outputs.prefix}}
+      - name: make
+        run: nmake
+      - name: test
+        run: nmake test TESTS=tests
+
   phpt-test:
     name: "PHPT Tests"
     services:

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -11,10 +11,11 @@ jobs:
       run:
         shell: cmd
     strategy:
+      fail-fast: false
       matrix:
-        version: [ "8.1" ]
-        arch: [ x64 ]
-        ts: [ ts ]
+        version: [ "8.1", "8.0", "7.4", "7.3", "7.2", "7.1" ]
+        arch: [ x64, x86 ]
+        ts: [ ts, nts ]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
@@ -38,10 +39,6 @@ jobs:
         run: sed -i 's/-d extension=/-d zend_extension=/g' Makefile
       - name: make
         run: nmake
-      - name: THING
-        run: |
-          cat Makefile
-          ls -l D:\a\scout-apm-php-ext\scout-apm-php-ext\x64\Release_TS\
       - name: test
         run: nmake test
 

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -34,10 +34,16 @@ jobs:
         run: phpize
       - name: configure
         run: configure --enable-scoutapm --with-prefix=${{steps.setup-php.outputs.prefix}}
+      - name: Zend extension
+        run: sed -i 's/-d extension=/-d zend_extension=/g' Makefile
       - name: make
         run: nmake
+      - name: THING
+        run: |
+          cat Makefile
+          ls -l D:\a\scout-apm-php-ext\scout-apm-php-ext\x64\Release_TS\
       - name: test
-        run: nmake test TESTS=tests
+        run: nmake test
 
   phpt-test:
     name: "PHPT Tests"

--- a/.gitignore
+++ b/.gitignore
@@ -49,12 +49,17 @@ shtool
 /config.log
 /configure.ac
 /config.status
+/config.nice.bat
+/configure.bat
+/configure.js
 
 # phpize
 /run-tests.php
+/run-tests.php:Zone.Identifier:$DATA
 .libs
 Makefile*
 build
+x64
 tests/*.diff
 tests/*.exp
 tests/*.log

--- a/CREDITS
+++ b/CREDITS
@@ -1,3 +1,2 @@
-;; scoutapm
-Chris Schneider <chris@scoutapm.com> (lead)
-James Titcumb [asgrim] <james@asgrim.com> (lead)
+scoutapm
+Chris Schneider (lead), James Titcumb [asgrim] (lead)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,34 @@ zbacktrace
 print_cvs
 ```
 
+## Windows builds
+
+ - Read this guide to put below into context: https://wiki.php.net/internals/windows/stepbystepbuild_sdk_2
+ - Read this guide to help get the environment set up: https://gist.github.com/cmb69/47b8c7fb392f5d79b245c74ac496632c
+ - PHP Binary tools - use https://github.com/php/php-sdk-binary-tools (**not** the Microsoft one as it is not maintained)
+ - Once the VS tools + php-sdk-binary-tools is installed, everything is done in this shell:
+   - Start > `Developer Command Prompt for VS 2019`
+   - Then `cd C:\php-sdk`
+   - Then `phpsdk-vs16-x64.bat` - you should now have a prompt `$ `
+ - Install PHP from https://windows.php.net/download/
+   - Download, e.g. ZTS build, https://windows.php.net/downloads/releases/php-8.1.7-Win32-vs16-x64.zip
+   - Extract into `C:\php`
+ - Prepare to compile the ext
+   - Download "Development package" from https://windows.php.net/download/ - make sure TS/NTS depending on above compilation
+     - e.g. https://windows.php.net/downloads/releases/php-devel-pack-8.1.7-nts-Win32-vs16-x64.zip
+   - Extract to `C:\php-sdk\php-8.1.7-devel-vs16-x64`
+   - Add `C:\php-sdk\php-8.1.7-devel-vs16-x64` to your PATH (Start > `env` > Environment variables > "Path" > New)
+   - restart the shell
+ - Compile the ext - go to the ext directory (mine was a VM, mounted in `Z:\`)
+   - Run `winbuild.bat`
+   - Or alternatively:
+     - `phpize`
+     - `configure --enable-scoutapm --enable-debug --with-php-build="C:\php-sdk\phpdev\vs16\x64\deps" --with-prefix="C:\php\"`
+     - `nmake`
+     - Edit `Makefile` - find `CC="$(PHP_CL)"` and replace with `CC="cl.exe"` - for some reason that variable substitution didn't work
+     - Also replace `-d extension=` with `-d zend_extension=`
+     - Run `nmake run ARGS="-m"` and check scoutapm exists in both PHP Modules and Zend modules
+
 ## Release Procedure
 
  - Open `package.xml`

--- a/config.w32
+++ b/config.w32
@@ -1,29 +1,29 @@
 // vim:ft=javascript
+(function () {
+	ARG_ENABLE('scoutapm', 'Whether to enable scoutapm support', 'no');
+	ARG_ENABLE('scoutapm-debug', 'Whether to enable scoutapm debugging', 'no');
 
-ARG_ENABLE('scoutapm', 'Whether to enable scoutapm support', 'no');
-ARG_ENABLE('scoutapm-debug', 'Whether to enable scoutapm debugging', 'no');
+	if (PHP_SCOUTAPM != 'no') {
+		var scoutapm_sources = 'zend_scoutapm.c ' +
+			'scout_observer.c ' +
+			'scout_execute_ex.c ' +
+			'scout_internal_handlers.c ' +
+			'scout_recording.c ' +
+			'scout_functions.c ' +
+			'scout_utils.c ' +
+			'scout_curl_wrapper.c ' +
+			'scout_file_wrapper.c ' +
+			'scout_pdo_wrapper.c ';
 
-if(PHP_SCOUTAPM != 'no')
-{
-	var scoutapm_sources = 	'zend_scoutapm.c ' +
-							'scout_observer.c ' +
-							'scout_execute_ex.c ' +
-							'scout_internal_handlers.c ' +
-							'scout_recording.c ' +
-							'scout_functions.c ' +
-							'scout_utils.c ' +
-							'scout_curl_wrapper.c ' +
-							'scout_file_wrapper.c ' +
-							'scout_pdo_wrapper.c ';
+		AC_DEFINE('HAVE_SCOUTAPM', 1);
+		ADD_FLAG('CFLAGS_SCOUTAPM', '/D WIN32_ONLY_COMPILER=1 /wd4005');
+		PHP_INSTALL_HEADERS("ext/scoutapm", "zend_scoutapm.h scout_recording.h scout_internal_handlers.h scout_extern.h scout_execute_ex.h");
 
-	AC_DEFINE('HAVE_SCOUTAPM', 1);
-	ADD_FLAG('CFLAGS_SCOUTAPM', '/D WIN32_ONLY_COMPILER=1 /wd4005');
-	PHP_INSTALL_HEADERS("ext/scoutapm", "zend_scoutapm.h scout_recording.h scout_internal_handlers.h scout_extern.h scout_execute_ex.h");
-
-	// PHP 7.1/7.2 don't have ZEND_EXTENSION
-	if (typeof(ZEND_EXTENSION) == 'undefined') {
-		EXTENSION('scoutapm', scoutapm_sources, true);
-	} else {
-		ZEND_EXTENSION('scoutapm', scoutapm_sources, true);
+		// PHP 7.1/7.2 don't have ZEND_EXTENSION
+		if (typeof (ZEND_EXTENSION) == 'undefined') {
+			EXTENSION('scoutapm', scoutapm_sources, true);
+		} else {
+			ZEND_EXTENSION('scoutapm', scoutapm_sources, true);
+		}
 	}
-}
+})();

--- a/config.w32
+++ b/config.w32
@@ -17,8 +17,8 @@ if(PHP_SCOUTAPM != 'no')
 							'scout_pdo_wrapper.c ';
 
 	AC_DEFINE('HAVE_SCOUTAPM', 1);
-	ADD_FLAG('CFLAGS_SCOUTAPM', '/D WIN32_ONLY_COMPILER=1');
+	ADD_FLAG('CFLAGS_SCOUTAPM', '/D WIN32_ONLY_COMPILER=1 /wd4005');
 	PHP_INSTALL_HEADERS("ext/scoutapm", "zend_scoutapm.h scout_recording.h scout_internal_handlers.h scout_extern.h scout_execute_ex.h");
 
-	ZEND_EXTENSION('scoutapm', scoutapm_sources);
+	ZEND_EXTENSION('scoutapm', scoutapm_sources, true);
 }

--- a/config.w32
+++ b/config.w32
@@ -20,5 +20,10 @@ if(PHP_SCOUTAPM != 'no')
 	ADD_FLAG('CFLAGS_SCOUTAPM', '/D WIN32_ONLY_COMPILER=1 /wd4005');
 	PHP_INSTALL_HEADERS("ext/scoutapm", "zend_scoutapm.h scout_recording.h scout_internal_handlers.h scout_extern.h scout_execute_ex.h");
 
-	ZEND_EXTENSION('scoutapm', scoutapm_sources, true);
+	// PHP 7.1/7.2 don't have ZEND_EXTENSION
+	if (typeof(ZEND_EXTENSION) == 'undefined') {
+		EXTENSION('scoutapm', scoutapm_sources, true);
+	} else {
+		ZEND_EXTENSION('scoutapm', scoutapm_sources, true);
+	}
 }

--- a/config.w32
+++ b/config.w32
@@ -20,5 +20,5 @@ if(PHP_SCOUTAPM != 'no')
 	ADD_FLAG('CFLAGS_SCOUTAPM', '/D WIN32_ONLY_COMPILER=1');
 	PHP_INSTALL_HEADERS("ext/scoutapm", "zend_scoutapm.h scout_recording.h scout_internal_handlers.h scout_extern.h scout_execute_ex.h");
 
-	EXTENSION('scoutapm', scoutapm_sources, PHP_SCOUTAPM_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+	ZEND_EXTENSION('scoutapm', scoutapm_sources);
 }

--- a/config.w32
+++ b/config.w32
@@ -1,0 +1,24 @@
+// vim:ft=javascript
+
+ARG_ENABLE('scoutapm', 'Whether to enable scoutapm support', 'no');
+ARG_ENABLE('scoutapm-debug', 'Whether to enable scoutapm debugging', 'no');
+
+if(PHP_SCOUTAPM != 'no')
+{
+	var scoutapm_sources = 	'zend_scoutapm.c ' +
+							'scout_observer.c ' +
+							'scout_execute_ex.c ' +
+							'scout_internal_handlers.c ' +
+							'scout_recording.c ' +
+							'scout_functions.c ' +
+							'scout_utils.c ' +
+							'scout_curl_wrapper.c ' +
+							'scout_file_wrapper.c ' +
+							'scout_pdo_wrapper.c ';
+
+	AC_DEFINE('HAVE_SCOUTAPM', 1);
+	ADD_FLAG('CFLAGS_SCOUTAPM', '/D WIN32_ONLY_COMPILER=1');
+	PHP_INSTALL_HEADERS("ext/scoutapm", "zend_scoutapm.h scout_recording.h scout_internal_handlers.h scout_extern.h scout_execute_ex.h");
+
+	EXTENSION('scoutapm', scoutapm_sources, PHP_SCOUTAPM_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+}

--- a/package.xml
+++ b/package.xml
@@ -12,16 +12,16 @@
         ScoutAPM's extension for PHP provides additional capabilities to application monitoring over just using the base PHP userland library.
     </description>
     <lead>
-        <name>Chris Schneider</name>
-        <user>cschneid</user>
-        <email>chris@scoutapm.com</email>
-        <active>yes</active>
-    </lead>
-    <lead>
         <name>James Titcumb</name>
         <user>asgrim</user>
         <email>james@asgrim.com</email>
         <active>yes</active>
+    </lead>
+    <lead>
+        <name>Chris Schneider</name>
+        <user>cschneid</user>
+        <email>chris@scoutapm.com</email>
+        <active>no</active>
     </lead>
 
     <!-- Current Release -->
@@ -46,6 +46,7 @@
     <contents>
         <dir name="/">
             <file name="config.m4" role="src" />
+            <file name="config.w32" role="src" />
             <file name="scout_curl_wrapper.c" role="src" />
             <file name="scout_execute_ex.c" role="src" />
             <file name="scout_execute_ex.h" role="src" />
@@ -64,7 +65,6 @@
             <file name="README.md" role="doc" />
             <file name="LICENSE" role="doc" />
             <file name="EXPERIMENTAL" role="doc" />
-            <file name="CREDITS" role="doc" />
             <dir name="tests">
                 <file name="external.inc" role="test" />
                 <file name="001-check-ext-loaded.phpt" role="test" />

--- a/scout_utils.c
+++ b/scout_utils.c
@@ -112,14 +112,17 @@ reference_retry_point:
             }
 
             should_free = 1;
-            DYNAMIC_MALLOC_SPRINTF(ret, len,
 #if PHP_VERSION_ID >= 80100
+            DYNAMIC_MALLOC_SPRINTF(ret, len,
                 "resource(%ld)",
-#else
-                "resource(%d)",
-#endif
                 Z_RES_HANDLE_P(original_to_copy)
             );
+#else
+            DYNAMIC_MALLOC_SPRINTF(ret, len,
+                "resource(%d)",
+                Z_RES_HANDLE_P(original_to_copy)
+            );
+#endif
             break;
         case IS_OBJECT:
 #if PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION == 1
@@ -181,14 +184,17 @@ reference_retry_point:
             );
             return ret;
         case IS_RESOURCE:
-            DYNAMIC_MALLOC_SPRINTF(ret, len,
 #if PHP_VERSION_ID >= 80100
+            DYNAMIC_MALLOC_SPRINTF(ret, len,
                 "resource(%ld)",
-#else
-                "resource(%d)",
-#endif
                 Z_RES_HANDLE_P(val)
             );
+#else
+            DYNAMIC_MALLOC_SPRINTF(ret, len,
+                "resource(%d)",
+                Z_RES_HANDLE_P(val)
+            );
+#endif
             return ret;
         case IS_ARRAY:
             return strdup("array");
@@ -220,16 +226,21 @@ const char *unique_resource_id(const char *scout_wrapper_type, zval *resource_id
         return "";
     }
 
-    DYNAMIC_MALLOC_SPRINTF(ret, len,
 #if PHP_VERSION_ID >= 80100
+    DYNAMIC_MALLOC_SPRINTF(ret, len,
         "%s_handle(%ld)_type(%d)",
-#else
-        "%s_handle(%d)_type(%d)",
-#endif
         scout_wrapper_type,
         Z_RES_HANDLE_P(resource_id),
         Z_RES_TYPE_P(resource_id)
     );
+#else
+    DYNAMIC_MALLOC_SPRINTF(ret, len,
+        "%s_handle(%d)_type(%d)",
+        scout_wrapper_type,
+        Z_RES_HANDLE_P(resource_id),
+        Z_RES_TYPE_P(resource_id)
+    );
+#endif
     return ret;
 }
 

--- a/tests/002-file_get_contents.phpt
+++ b/tests/002-file_get_contents.phpt
@@ -27,5 +27,5 @@ float(%f)
 bool(true)
 array(1) {
   [0]=>
-  string(%d) "%s/tests/002-file_get_contents.php"
+  string(%d) "%s%etests%e002-file_get_contents.php"
 }

--- a/tests/004-namespaced-fgc-is-not-logged.phpt
+++ b/tests/004-namespaced-fgc-is-not-logged.phpt
@@ -64,7 +64,7 @@ array(1) {
     ["argv"]=>
     array(1) {
       [0]=>
-      string(%d) "%s/tests/004-namespaced-fgc-is-not-logged.php"
+      string(%d) "%s%etests%e004-namespaced-fgc-is-not-logged.php"
     }
   }
 }

--- a/tests/010-fwrite-fread-fopen.phpt
+++ b/tests/010-fwrite-fread-fopen.phpt
@@ -31,14 +31,14 @@ fread/fwrite test
 string(6) "fwrite"
 array(2) {
   [0]=>
-  string(%d) "/tmp/scoutapm-test%s"
+  string(%d) "%s"
   [1]=>
   string(%d) "w+"
 }
 string(5) "fread"
 array(2) {
   [0]=>
-  string(%d) "/tmp/scoutapm-test%s"
+  string(%d) "%s"
   [1]=>
   string(%d) "w+"
 }

--- a/tests/012-file_put_contents.phpt
+++ b/tests/012-file_put_contents.phpt
@@ -22,7 +22,7 @@ string(12) "test content"
 string(17) "file_put_contents"
 array(2) {
   [0]=>
-  string(%d) "%sscout-apm-php-ext-test%s"
+  string(%d) "%s"
   [1]=>
   string(12) "test content"
 }

--- a/tests/bug-88.phpt
+++ b/tests/bug-88.phpt
@@ -2,6 +2,7 @@
 Bug https://github.com/scoutapp/scout-apm-php-ext/issues/88 - memory usage should not increase when no instrumentation happens
 --SKIPIF--
 <?php if (!extension_loaded("scoutapm")) die("skip scoutapm extension required."); ?>
+<?php if (stripos(PHP_OS, 'Win') === 0) die("skip not for Windows."); ?>
 --FILE--
 <?php
 

--- a/tests/bug-88.phpt
+++ b/tests/bug-88.phpt
@@ -2,7 +2,7 @@
 Bug https://github.com/scoutapp/scout-apm-php-ext/issues/88 - memory usage should not increase when no instrumentation happens
 --SKIPIF--
 <?php if (!extension_loaded("scoutapm")) die("skip scoutapm extension required."); ?>
-<?php if (stripos(PHP_OS, 'Win') === 0) die("skip not for Windows."); ?>
+<?php /* PHP_OS_FAMILY === "Windows" - needs PHP 7.2+ */ if (stripos(PHP_OS, 'Win') === 0) die("skip not for Windows."); ?>
 --FILE--
 <?php
 

--- a/winbuild.bat
+++ b/winbuild.bat
@@ -2,6 +2,5 @@ rmdir /S /Q x64
 call phpize
 call configure --enable-scoutapm --enable-debug --with-php-build="C:\php-sdk\phpdev\vs16\x64\deps" --with-prefix="C:\php\"
 call sed -i 's/-d extension=/-d zend_extension=/g' Makefile
-call sed -i 's/CC="$(PHP_CL)"/CC="cl.exe"/g' Makefile
-call nmake
+call nmake CC=cl.exe
 call nmake run ARGS="-m"

--- a/winbuild.bat
+++ b/winbuild.bat
@@ -1,0 +1,7 @@
+rmdir /S /Q x64
+call phpize
+call configure --enable-scoutapm --enable-debug --with-php-build="C:\php-sdk\phpdev\vs16\x64\deps" --with-prefix="C:\php\"
+call sed -i 's/-d extension=/-d zend_extension=/g' Makefile
+call sed -i 's/CC="$(PHP_CL)"/CC="cl.exe"/g' Makefile
+call nmake
+call nmake run ARGS="-m"

--- a/zend_scoutapm.c
+++ b/zend_scoutapm.c
@@ -90,13 +90,13 @@ ZEND_TSRMLS_CACHE_DEFINE()
 #endif
 
 /* extension_version_info is used by PHP */
-zend_extension_version_info extension_version_info = {
+ZEND_DLEXPORT zend_extension_version_info extension_version_info = {
     ZEND_EXTENSION_API_NO,
     (char*) ZEND_EXTENSION_BUILD_ID
 };
 
 /* zend_extension_entry provides the metadata/information for PHP about this zend extension */
-zend_extension zend_extension_entry = {
+ZEND_DLEXPORT zend_extension zend_extension_entry = {
     (char*) PHP_SCOUTAPM_NAME,
     (char*) PHP_SCOUTAPM_VERSION,
     (char*) "Scout APM",

--- a/zend_scoutapm.h
+++ b/zend_scoutapm.h
@@ -8,7 +8,9 @@
 #ifndef ZEND_SCOUTAPM_H
 #define ZEND_SCOUTAPM_H
 
+#ifdef HAVE_CONFIG_H
 #include "config.h"
+#endif
 
 #include "php.h"
 #include <zend_extensions.h>


### PR DESCRIPTION
As per description, this adds support for Windows. Key discoveries made in this investigation

 - @cmb69 is very knowledgeable and has been immensely helpful, thank you
 - Windows compilation does not like pre-processor conditionals in the middle of a macro
 - CREDITS file was breaking things, so I've removed it for now - see php/php-src#8767
 - extension version info / entry should be exported with `ZEND_DLEXPORT` - see phpinternalsbook/PHP-Internals-Book#126
 - `config.h` does not exist on Windows

For most of the part though, it was just tests needing updates with things like directory separators, or tests that assume we're on Linux (which have been skipped for now).