### PR TITLE
Allow PHP 8.2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -104,7 +104,7 @@
         <required>
             <php>
                 <min>7.1.0</min>
-                <max>8.1.99</max>
+                <max>8.2.99</max>
             </php>
             <pearinstaller>
                 <min>1.9.1</min>


### PR DESCRIPTION
As it seems compatible

```
=====================================================================
PHP         : /opt/remi/php82/root/usr/bin/php 
PHP_SAPI    : cli
PHP_VERSION : 8.2.0RC2
ZEND_VERSION: 4.2.0RC2
PHP_OS      : Linux - Linux builder.remirepo.net 5.19.8-100.fc35.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Sep 8 19:23:03 UTC 2022 x86_64
INI actual  : /dev/shm/BUILD/php82-php-pecl-scoutapm-1.8.2/NTS
More .INIs  :  
---------------------------------------------------------------------
PHP         : /opt/remi/php82/root/usr/bin/php-cgi 
PHP_SAPI    : cgi-fcgi
PHP_VERSION : 8.2.0RC2
ZEND_VERSION: 4.2.0RC2
PHP_OS      : Linux - Linux builder.remirepo.net 5.19.8-100.fc35.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Sep 8 19:23:03 UTC 2022 x86_64
INI actual  : /dev/shm/BUILD/php82-php-pecl-scoutapm-1.8.2/NTS
More .INIs  : 
--------------------------------------------------------------------- 
CWD         : /dev/shm/BUILD/php82-php-pecl-scoutapm-1.8.2/NTS
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
TIME START 2022-09-15 07:11:33
=====================================================================
PASS Check Scout APM extension is loaded [tests/001-check-ext-loaded.phpt] 
PASS Calls to file_get_contents are logged [tests/002-file_get_contents.phpt] 
PASS Ensures that calls to scoutapm_get_calls() clears the call list [tests/003-scoutapm_get_calls-clears-calls-list.phpt] 
PASS Calls to file_get_contents are logged [tests/004-namespaced-fgc-is-not-logged.phpt] 
PASS Requires to external files do not crash [tests/005-requiring-external-files-handled.phpt] 
PASS Executing a closure/anonymous function does not crash [tests/006-anonymous-classes-handled.phpt] 
PASS Running evaled code does not crash [tests/007-evaled-code-handled.phpt] 
PASS Class without a defined constructor does not crash [tests/008-class-with-no-constructor-call-handled.phpt] 
PASS Calls to curl_exec are logged [tests/009-curl_exec.phpt] 
PASS Calls to fwrite and fread are logged with handle from fopen() [tests/010-fwrite-fread-fopen.phpt] 
PASS Calls to fwrite and fread are logged with handle from tmpfile() [tests/010-fwrite-fread-tmpfile.phpt] 
PASS Calls to PDO::exec are logged [tests/011-pdo-exec.phpt] 
PASS Calls to PDO::query are logged [tests/011-pdo-query.phpt] 
PASS Calls to PDOStatement::execute are logged when created from PDO->prepare() [tests/011-pdostatement-execute-pdo-prepare.phpt] 
PASS Calls to file_put_contents are logged [tests/012-file_put_contents.phpt] 
SKIP When calls to functions are recorded, and scoutapm_get_calls is not called, don't leak memory [tests/013-fix-memory-leak-when-scoutapm_get_calls-not-called.phpt] reason: Recompile PHP with --enable-debug.
SKIP Predis userland functions are supported [tests/014-predis-support.phpt] reason: Connection refused [tcp://127.0.0.1:6379]
SKIP PHP Redis C extension functions are instrumented [tests/015-phpredis-support.phpt] reason: redis extension required.
SKIP Memcached C extension functions are instrumented [tests/016-memcached-support.phpt] reason: memcached extension required.
PASS Do not instrument anything by default, unless scoutapm_enable_instrumentation(true) is called [tests/018-do-not-instrument-by-default.phpt] 
PASS Both URL and Method can be captured using file_get_contents [tests/019-url-method-capture-fgc.phpt] 
PASS Both URL and Method can be captured using curl + CURLOPT_POST [tests/020-url-method-capture-curl-post.phpt] 
PASS Both URL and Method can be captured using curl + CURLOPT_CUSTOMREQUEST [tests/021-url-method-capture-curl-customreq.phpt] 
PASS Bug https://github.com/scoutapp/scout-apm-php-ext/issues/47 - fix segfault when accessing argument store out of bounds [tests/bug-47.phpt] 
PASS Bug https://github.com/scoutapp/scout-apm-php-ext/issues/49 - only record arguments for fopen if it returns a resource [tests/bug-49.phpt] 
PASS Bug https://github.com/scoutapp/scout-apm-php-ext/issues/55 - don't crash when using an observed method in extended class [tests/bug-55.phpt] 
PASS Bug https://github.com/scoutapp/scout-apm-php-ext/issues/71 - only record arguments for prepare if it returns an object [tests/bug-71.phpt] 
PASS Bug https://github.com/scoutapp/scout-apm-php-ext/issues/88 - memory usage should not increase when no instrumentation happens [tests/bug-88.phpt] 
PASS Bug https://github.com/scoutapp/scout-apm-php-ext/issues/93 - Should not segfault on static function usage [tests/bug-93.phpt] 
=====================================================================
TIME END 2022-09-15 07:11:36

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   72
---------------------------------------------------------------------

Number of tests :   29                25
Tests skipped   :    4 ( 13.8%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :   25 ( 86.2%) (100.0%)
---------------------------------------------------------------------
Time taken      :    3 seconds
=====================================================================

```